### PR TITLE
Update latest.json

### DIFF
--- a/latest.json
+++ b/latest.json
@@ -1,9 +1,9 @@
 [   
    {
-  "title": "Minecraft Java - 1.18 Experimental Snapshot",
-    "url": "https://www.minecraft.net/en-us/article/new-world-generation-java-available-testing",
-    "image": "https://www.minecraft.net/content/dam/games/minecraft/screenshots/worlgeneration-header.jpg",
-    "date": "2021-7-13",
+  "title": "Minecraft Java - Snapshot 21w38a",
+    "url": "https://www.minecraft.net/en-us/article/minecraft-snapshot-21w38a",
+    "image": "https://www.minecraft.net/content/dam/games/minecraft/screenshots/snapshot-21w38a-header.jpg",
+    "date": "2021-9-23",
     "category": "java"
   },
    {


### PR DESCRIPTION
Ho appena visto che avete lasciato lo snapshot della 1.18 quando ci doveva essere solo 1 spazio libero per gli snapshot.
Rivedi il [pull #17](https://github.com/minehub-it/articles/pull/17)